### PR TITLE
Optimize Boost Pads

### DIFF
--- a/Assets/Prefabs/Player_New.prefab
+++ b/Assets/Prefabs/Player_New.prefab
@@ -4886,6 +4886,7 @@ MonoBehaviour:
   TimeText: {fileID: 0}
   TimeLabelVR: {fileID: 0}
   TimeTextVR: {fileID: 0}
+  Addons: {fileID: 0}
 --- !u!1 &8736114677415470375
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Roads/RoadTileBlock SlightInclncline.prefab
+++ b/Assets/Prefabs/Roads/RoadTileBlock SlightInclncline.prefab
@@ -321,7 +321,7 @@ GameObject:
   - component: {fileID: 4688074101469706878}
   m_Layer: 0
   m_Name: TileSurface
-  m_TagString: Untagged
+  m_TagString: TileCollider
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -476,6 +476,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 2241649302531590236}
   - {fileID: 3330711060529505411}
   - {fileID: 6196810337436782732}
   - {fileID: 4791730847721367001}
@@ -518,9 +519,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bHasBeenVisited: 0
   TileIndex: 0
-  bHasBoosts: 0
+  bHasBoosts: 1
   spawnsObstacles: 1
   TileSurface: {fileID: 3375934951791937384}
+  RaycastSpawner: {fileID: 7565725888910075855}
+  maxBoostPads: 2
   obstaclePrefabs:
   - {fileID: 2622329401361513194, guid: 838d037d4afc66f448e87e9084047f10, type: 3}
   obstacleSpawnPoints:
@@ -610,3 +613,56 @@ Transform:
   m_Children: []
   m_Father: {fileID: 4791730847721367001}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9062480694612315953
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2241649302531590236}
+  - component: {fileID: 7565725888910075855}
+  m_Layer: 0
+  m_Name: RaycastSpawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2241649302531590236
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9062480694612315953}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 5, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4509758294643501400}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &7565725888910075855
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9062480694612315953}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 10, y: 0, z: 10}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/Roads/RoadTileBlock.prefab
+++ b/Assets/Prefabs/Roads/RoadTileBlock.prefab
@@ -211,6 +211,59 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1421386484465057762
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3590742829509650666}
+  - component: {fileID: 2129463332433689621}
+  m_Layer: 0
+  m_Name: RaycastPlane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3590742829509650666
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1421386484465057762}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 5, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4509758294643501400}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2129463332433689621
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1421386484465057762}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 10, y: 0, z: 10}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1829066730073431393
 GameObject:
   m_ObjectHideFlags: 0
@@ -413,6 +466,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 3590742829509650666}
   - {fileID: 3330711060529505411}
   - {fileID: 8077320513137464444}
   - {fileID: 6292153894028271904}
@@ -458,6 +512,8 @@ MonoBehaviour:
   bHasBoosts: 1
   spawnsObstacles: 1
   TileSurface: {fileID: 3375934951791937384}
+  RaycastSpawner: {fileID: 2129463332433689621}
+  maxBoostPads: 2
   obstaclePrefabs:
   - {fileID: 2622329401361513194, guid: 838d037d4afc66f448e87e9084047f10, type: 3}
   - {fileID: 8679202041979607770, guid: e5def73a0fa719045a894f8c787e81e0, type: 3}

--- a/Assets/Prefabs/Roads/RoadTileBlock_LeftTile.prefab
+++ b/Assets/Prefabs/Roads/RoadTileBlock_LeftTile.prefab
@@ -410,6 +410,59 @@ Transform:
   - {fileID: 7108833113887671299}
   m_Father: {fileID: 4509758294643501400}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5520085867992508587
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2008418253371017454}
+  - component: {fileID: 4529566404028787301}
+  m_Layer: 0
+  m_Name: RaycastPlane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2008418253371017454
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5520085867992508587}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 5, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4509758294643501400}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4529566404028787301
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5520085867992508587}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 10, y: 0, z: 10}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5779373908981192658
 GameObject:
   m_ObjectHideFlags: 0
@@ -442,6 +495,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 2008418253371017454}
   - {fileID: 3330711060529505411}
   - {fileID: 2240047155686794110}
   - {fileID: 7350241900110799108}
@@ -484,9 +538,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bHasBeenVisited: 0
   TileIndex: 0
-  bHasBoosts: 0
+  bHasBoosts: 1
   spawnsObstacles: 1
   TileSurface: {fileID: 3375934951791937384}
+  RaycastSpawner: {fileID: 4529566404028787301}
+  maxBoostPads: 2
   obstaclePrefabs:
   - {fileID: 7171657923609553380, guid: c9c048807845554449768690c64e98fb, type: 3}
   - {fileID: 7171657923609553380, guid: 47c5a601bb4f37c41a26a3f7ac15b996, type: 3}

--- a/Assets/Prefabs/Roads/RoadTileBlock_RightTilt.prefab
+++ b/Assets/Prefabs/Roads/RoadTileBlock_RightTilt.prefab
@@ -444,6 +444,59 @@ Transform:
   - {fileID: 7108833113887671299}
   m_Father: {fileID: 4509758294643501400}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4646967915348797377
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3023800351267699034}
+  - component: {fileID: 4292294387451288860}
+  m_Layer: 0
+  m_Name: RaycastPlane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3023800351267699034
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4646967915348797377}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 5, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4509758294643501400}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4292294387451288860
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4646967915348797377}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 10, y: 0, z: 10}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5779373908981192658
 GameObject:
   m_ObjectHideFlags: 0
@@ -476,6 +529,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 3023800351267699034}
   - {fileID: 3330711060529505411}
   - {fileID: 6461123901405827457}
   - {fileID: 4850734974048215276}
@@ -518,9 +572,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bHasBeenVisited: 0
   TileIndex: 0
-  bHasBoosts: 0
+  bHasBoosts: 1
   spawnsObstacles: 1
   TileSurface: {fileID: 3375934951791937384}
+  RaycastSpawner: {fileID: 4292294387451288860}
+  maxBoostPads: 2
   obstaclePrefabs:
   - {fileID: 7171657923609553380, guid: c9c048807845554449768690c64e98fb, type: 3}
   - {fileID: 7171657923609553380, guid: 47c5a601bb4f37c41a26a3f7ac15b996, type: 3}

--- a/Assets/Prefabs/Roads/RoadTileBlock_Roof.prefab
+++ b/Assets/Prefabs/Roads/RoadTileBlock_Roof.prefab
@@ -1428,6 +1428,59 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &3768912449287876972
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7198351470593990870}
+  - component: {fileID: 9210463159414845302}
+  m_Layer: 0
+  m_Name: RaycastPlane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7198351470593990870
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3768912449287876972}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 5, z: 10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4509758294643501400}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &9210463159414845302
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3768912449287876972}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 10, y: 0, z: 20}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &4037206326894954801
 GameObject:
   m_ObjectHideFlags: 0
@@ -1937,6 +1990,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 7198351470593990870}
   - {fileID: 3976577040619878470}
   - {fileID: 7874510727368167458}
   - {fileID: 7108833113887671299}
@@ -1982,7 +2036,10 @@ MonoBehaviour:
   bHasBeenVisited: 0
   TileIndex: 0
   bHasBoosts: 1
+  spawnsObstacles: 0
   TileSurface: {fileID: 6096593309324440287}
+  RaycastSpawner: {fileID: 9210463159414845302}
+  maxBoostPads: 4
   obstaclePrefabs: []
   obstacleSpawnPoints: []
   boostRampPrefab: {fileID: 5351845041639648242, guid: 062ea8c102ce80a45a7f0682e9ae173a,

--- a/Assets/Prefabs/Roads/RoadTileBlock_Segment_Drop.prefab
+++ b/Assets/Prefabs/Roads/RoadTileBlock_Segment_Drop.prefab
@@ -1513,6 +1513,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 8329510250453459700}
   - {fileID: 8885580280309232919}
   - {fileID: 8183108616479934408}
   - {fileID: 7108833113887671299}
@@ -1557,11 +1558,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bHasBeenVisited: 0
   TileIndex: 0
-  bHasBoosts: 0
+  bHasBoosts: 1
+  spawnsObstacles: 0
   TileSurface: {fileID: 8277909507968286574}
+  RaycastSpawner: {fileID: 6855014299964784866}
+  maxBoostPads: 6
   obstaclePrefabs: []
   obstacleSpawnPoints: []
-  boostRampPrefab: {fileID: 0}
+  boostRampPrefab: {fileID: 5351845041639648242, guid: 062ea8c102ce80a45a7f0682e9ae173a,
+    type: 3}
 --- !u!114 &1374348960883039881
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1822,6 +1827,59 @@ Transform:
   m_Children: []
   m_Father: {fileID: 4509758294643501400}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7249275301337821891
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8329510250453459700}
+  - component: {fileID: 6855014299964784866}
+  m_Layer: 0
+  m_Name: RaycastPlane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8329510250453459700
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7249275301337821891}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 5, z: 15}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4509758294643501400}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &6855014299964784866
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7249275301337821891}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 10, y: 0, z: 30}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &8277909507968286574
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Roads/RoadTileBlock_SlightDecline.prefab
+++ b/Assets/Prefabs/Roads/RoadTileBlock_SlightDecline.prefab
@@ -378,6 +378,59 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &5661609872021061316
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3834211202115874699}
+  - component: {fileID: 5268642287861785350}
+  m_Layer: 0
+  m_Name: RaycastPlane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3834211202115874699
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5661609872021061316}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 5, z: 5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4509758294643501400}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &5268642287861785350
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5661609872021061316}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 10, y: 0, z: 10}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5779373908981192658
 GameObject:
   m_ObjectHideFlags: 0
@@ -410,6 +463,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 3834211202115874699}
   - {fileID: 3330711060529505411}
   - {fileID: 4767674947038256531}
   - {fileID: 6070854695893829846}
@@ -452,9 +506,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bHasBeenVisited: 0
   TileIndex: 0
-  bHasBoosts: 0
+  bHasBoosts: 1
   spawnsObstacles: 1
   TileSurface: {fileID: 3375934951791937384}
+  RaycastSpawner: {fileID: 5268642287861785350}
+  maxBoostPads: 2
   obstaclePrefabs:
   - {fileID: 2622329401361513194, guid: 838d037d4afc66f448e87e9084047f10, type: 3}
   - {fileID: 8679202041979607770, guid: e5def73a0fa719045a894f8c787e81e0, type: 3}

--- a/Assets/Prefabs/Roads/RoadTileBlock_Split.prefab
+++ b/Assets/Prefabs/Roads/RoadTileBlock_Split.prefab
@@ -797,6 +797,59 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &5661899537164154060
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 443391742953997873}
+  - component: {fileID: 3532237595033894360}
+  m_Layer: 0
+  m_Name: RaycastPlane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &443391742953997873
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5661899537164154060}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 5, z: 10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4509758294643501400}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &3532237595033894360
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5661899537164154060}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 10, y: 0, z: 20}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5779373908981192658
 GameObject:
   m_ObjectHideFlags: 0
@@ -829,6 +882,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 443391742953997873}
   - {fileID: 6133601615336568571}
   - {fileID: 8183108616479934408}
   - {fileID: 7108833113887671299}
@@ -871,11 +925,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bHasBeenVisited: 0
   TileIndex: 0
-  bHasBoosts: 0
+  bHasBoosts: 1
+  spawnsObstacles: 0
   TileSurface: {fileID: 1331210212388284007}
+  RaycastSpawner: {fileID: 3532237595033894360}
+  maxBoostPads: 4
   obstaclePrefabs: []
   obstacleSpawnPoints: []
-  boostRampPrefab: {fileID: 0}
+  boostRampPrefab: {fileID: 5351845041639648242, guid: 062ea8c102ce80a45a7f0682e9ae173a,
+    type: 3}
 --- !u!114 &1374348960883039881
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Roads/RoadTileBlock_Split_Raise.prefab
+++ b/Assets/Prefabs/Roads/RoadTileBlock_Split_Raise.prefab
@@ -3120,6 +3120,59 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &4942550163040309075
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5345109172572789376}
+  - component: {fileID: 8337071365556291726}
+  m_Layer: 0
+  m_Name: RaycastPlane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5345109172572789376
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4942550163040309075}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 10, z: 15}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4509758294643501400}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &8337071365556291726
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4942550163040309075}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 10, y: 0, z: 30}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5006924697448874362
 GameObject:
   m_ObjectHideFlags: 0
@@ -3574,6 +3627,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 5345109172572789376}
   - {fileID: 5247440769210901513}
   - {fileID: 8183108616479934408}
   - {fileID: 7108833113887671299}
@@ -3616,11 +3670,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   bHasBeenVisited: 0
   TileIndex: 0
-  bHasBoosts: 0
+  bHasBoosts: 1
+  spawnsObstacles: 0
   TileSurface: {fileID: 657434552146606114}
+  RaycastSpawner: {fileID: 8337071365556291726}
+  maxBoostPads: 4
   obstaclePrefabs: []
   obstacleSpawnPoints: []
-  boostRampPrefab: {fileID: 0}
+  boostRampPrefab: {fileID: 5351845041639648242, guid: 062ea8c102ce80a45a7f0682e9ae173a,
+    type: 3}
 --- !u!114 &1374348960883039881
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Roads/RoadTileBlock_Thin.prefab
+++ b/Assets/Prefabs/Roads/RoadTileBlock_Thin.prefab
@@ -242,6 +242,59 @@ Transform:
   m_Children: []
   m_Father: {fileID: 6955246856355742854}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1932558660022801179
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7634846235907628647}
+  - component: {fileID: 6547085179673534531}
+  m_Layer: 0
+  m_Name: RaycastPlane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7634846235907628647
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1932558660022801179}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 5, z: 10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4509758294643501400}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &6547085179673534531
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1932558660022801179}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 5, y: 0, z: 20}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &2634233794248093823
 GameObject:
   m_ObjectHideFlags: 0
@@ -798,6 +851,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 7634846235907628647}
   - {fileID: 6919480281195739042}
   - {fileID: 7936031225739002966}
   - {fileID: 7108833113887671299}
@@ -843,6 +897,8 @@ MonoBehaviour:
   bHasBoosts: 1
   spawnsObstacles: 0
   TileSurface: {fileID: 8742673305681860989}
+  RaycastSpawner: {fileID: 6547085179673534531}
+  maxBoostPads: 2
   obstaclePrefabs: []
   obstacleSpawnPoints: []
   boostRampPrefab: {fileID: 5351845041639648242, guid: 062ea8c102ce80a45a7f0682e9ae173a,

--- a/Assets/Scripts/Gameplay/Missions/Mission7/RoadTile.cs
+++ b/Assets/Scripts/Gameplay/Missions/Mission7/RoadTile.cs
@@ -1,9 +1,12 @@
 using ExitGames.Client.Photon.StructWrapping;
+using Nobi.UiRoundedCorners;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Unity.Mathematics;
 using UnityEngine;
 using UnityEngine.Rendering;
+using UnityEngine.Timeline;
 
 [System.Serializable]
 
@@ -15,6 +18,8 @@ public class RoadTile : MonoBehaviour
     public bool bHasBoosts;
     public bool spawnsObstacles;
     public GameObject TileSurface;
+    public BoxCollider RaycastSpawner;
+    public int maxBoostPads;
 
     // Start is called before the first frame update
     private void Start()
@@ -45,8 +50,8 @@ public class RoadTile : MonoBehaviour
         if (obstacleSpawnPoints.Count == 0 || obstacleSpawnPoints == null) return;
 
         //updated to select obstacle spawn point from list of spawns
-        int itemIndex = Random.Range(0, obstaclePrefabs.Count);
-        int itemSpawnIndex = Random.Range(0, obstacleSpawnPoints.Count);
+        int itemIndex = UnityEngine.Random.Range(0, obstaclePrefabs.Count);
+        int itemSpawnIndex = UnityEngine.Random.Range(0, obstacleSpawnPoints.Count);
         Transform spawnPoint = obstacleSpawnPoints[itemSpawnIndex].transform;
 
         Instantiate(obstaclePrefabs[itemIndex], spawnPoint.position, Quaternion.identity, transform);
@@ -61,8 +66,8 @@ public class RoadTile : MonoBehaviour
             return;
         }
 
-        int rampToSpawn = 2;
-        for (int i = 0; i < rampToSpawn; i++)
+        //removed hardcoded 2 for pad variable (default to 2)
+        for (int i = 0; i < maxBoostPads; i++)
         {
             GameObject temp = Instantiate(boostRampPrefab, transform);
             try
@@ -71,11 +76,18 @@ public class RoadTile : MonoBehaviour
                 if (collider = null) throw new System.Exception("Invalid collider!");
 
                 //find spawn point on the tile for the instantiated boostpad
-                temp.transform.position = GetRandomPointInCollider(TileSurface.transform.GetComponent<Collider>(), temp.transform.GetComponent<Collider>());
-                Debug.Log($"Height: {temp.transform.position}");
-                temp.transform.rotation = TileSurface.transform.rotation;
+                Vector3 spawnPos;
+                Quaternion spawnRot;
 
-                Debug.Log($"BoostRamp spawned at: {temp.transform.position}");
+                if (SpawnBoost(RaycastSpawner, TileSurface, temp.transform.GetComponent<BoxCollider>(), out spawnPos, out spawnRot)) {
+                    temp.transform.SetPositionAndRotation(spawnPos, spawnRot);
+                }
+                else
+                {
+                    Destroy(temp); // remove unnused boosts
+                }
+
+                    Debug.Log($"BoostRamp spawned at: {temp.transform.position}");
             }
             catch (System.Exception e)
             {
@@ -86,7 +98,7 @@ public class RoadTile : MonoBehaviour
         }
     }
 
-    //evil recursive function blows up when no valid collider
+    //evil recursive function blows up when no valid collider - DEPRECIATED
     Vector3 GetRandomPointInCollider(Collider tileCollider, Collider toSpawnCollider)
     {
         if (tileCollider == null) throw new System.Exception("Invalid tile collider!");
@@ -98,9 +110,9 @@ public class RoadTile : MonoBehaviour
 
         //chose random point between bounds of tile + half size of new object
         Vector3 point = new Vector3(
-            Random.Range(tileCollider.bounds.min.x + toSpawnSize.x, tileCollider.bounds.max.x - toSpawnSize.x),
+            UnityEngine.Random.Range(tileCollider.bounds.min.x + toSpawnSize.x, tileCollider.bounds.max.x - toSpawnSize.x),
             tileCollider.bounds.max.y,
-            Random.Range(tileCollider.bounds.min.z + toSpawnSize.z, tileCollider.bounds.max.z - toSpawnSize.z)
+            UnityEngine.Random.Range(tileCollider.bounds.min.z + toSpawnSize.z, tileCollider.bounds.max.z - toSpawnSize.z)
         );
 
         Debug.Log($"Point: {point}");
@@ -113,4 +125,92 @@ public class RoadTile : MonoBehaviour
         Debug.Log($"Generated point: {point}");
         return point;
     }
+
+
+    //POLISH THIS
+    public bool SpawnBoost(BoxCollider raycastPlane, GameObject tileCollider, BoxCollider toSpawnCollider, out Vector3 spawnPos, out Quaternion spawnRot)
+    {
+        if (raycastPlane == null || toSpawnCollider == null || tileCollider == null) throw new System.Exception("Missing collider!");
+        int maxAttempts = 10;
+
+        //make several attempts to find a valid spawn location
+        for (int i = 0; i < maxAttempts; i++)
+        {
+            //find a point on the plane of the raycast spawner
+            float localX = UnityEngine.Random.Range(-0.5f, 0.5f) * raycastPlane.size.x;
+            float localZ = UnityEngine.Random.Range(-0.5f, 0.5f) * raycastPlane.size.z;
+            float bufferDistance = 0.05f;
+
+            Vector3 localPoint = new Vector3(localX, 0f, localZ) + raycastPlane.center;
+            Vector3 worldPoint = raycastPlane.transform.TransformPoint(localPoint);
+            Debug.Log($"Local Point: {localPoint}, World Point: {worldPoint}");
+
+            //make the scan and try to find a valid point
+            RaycastHit centreHit;
+            if (Physics.Raycast(worldPoint, Vector3.down, out centreHit, 10) && centreHit.transform.IsChildOf(tileCollider.gameObject.transform))
+            {
+                var marker = new GameObject("CentreMarker");
+                marker.transform.SetPositionAndRotation(centreHit.point, Quaternion.FromToRotation(Vector3.up, centreHit.normal));
+                marker.transform.SetParent(transform, true);
+
+                float toSpawnWidth = toSpawnCollider.size.x / 2 + bufferDistance;
+                float toSpawnLength = toSpawnCollider.size.z / 2 + bufferDistance;
+
+                //finding corners along axis of the potential spawn
+                var normalRot = Quaternion.FromToRotation(Vector3.up, centreHit.normal);
+                var normalRight = normalRot * Vector3.right;
+                var normalFwd = normalRot * Vector3.forward;
+                var temp = centreHit.point; temp.y += toSpawnCollider.size.y + bufferDistance;
+
+                Vector3[] corners = new Vector3[4];
+                corners[0] = temp; corners[0] = temp + (-normalRight * toSpawnWidth) + (-normalFwd * toSpawnLength);
+                corners[1] = temp; corners[1] = temp + (-normalRight * toSpawnWidth) + (normalFwd * toSpawnLength);
+                corners[2] = temp; corners[2] = temp + (normalRight * toSpawnWidth) + (-normalFwd * toSpawnLength);
+                corners[3] = temp; corners[3] = temp + (normalRight * toSpawnWidth) + (normalFwd * toSpawnLength);
+
+                //spawn a ray for each of the projected corners to see if we're in a valid spot
+                bool validCorner = false;
+                foreach (Vector3 corner in corners)
+                {
+                    bool impact = false;
+                    bool validImpact = false;
+                    RaycastHit cornerHit;
+
+                    Debug.Log($"Projected Point: {corner}");
+
+
+                    //if we go a little below the threshold and find a spot that is part of the road tile, then this is probably a valid point
+                    impact = Physics.Raycast(corner, -centreHit.normal, out cornerHit, toSpawnCollider.size.y + bufferDistance * 2);
+                    if (!impact) { validCorner = false; break; }
+
+                    Debug.Log($"Spawning GameObject for : {corner}");
+                    Quaternion cornerRot = Quaternion.FromToRotation(Vector3.up, cornerHit.normal);
+
+                    //debug purposes if needed
+                    marker = new GameObject("CornerMarker");
+                    marker.transform.SetPositionAndRotation(cornerHit.point, cornerRot);
+                    marker.transform.SetParent(transform, true);
+
+                    //make sure we haven't impact an obstacle or impacted outside our buffer range
+                    validImpact = (cornerHit.transform.IsChildOf(centreHit.transform));
+                    if (!validImpact) { validCorner = false; break; }
+
+                    validCorner = true;
+                }
+
+                if (!validCorner) break;
+
+                Quaternion rotation = Quaternion.FromToRotation(Vector3.up, centreHit.normal);
+                //Instantiate(boostRampPrefab, centreHit.point, rotation, transform);
+
+                Debug.Log($"BoostRamp spawned at: {centreHit.point}");
+                spawnPos = centreHit.point;
+                spawnRot = rotation;
+                return true;
+            }
+        }
+        spawnPos = Vector3.zero; spawnRot = Quaternion.identity;
+        return false;
+    }
+
 }


### PR DESCRIPTION
Overview:
Replaces the old recursive boost pad spawning system that causes stack overflows on any non-flat tile with a raycast based system that can handle complex geometry. Not quite finished yet - will complete in week 11 but PR'ing now to have link ready.

Original Design:
<img width="998" height="471" alt="BoostSpawner-Original drawio" src="https://github.com/user-attachments/assets/7d875ecc-b2cb-4af4-80f0-748c39ddcca1" />

Updated Design:
<img width="1119" height="781" alt="BoostSpawner-Update drawio" src="https://github.com/user-attachments/assets/a7f89369-8d1e-4f9d-a45f-dd2728c08146" />


Changes:
Scripts:
Assets/Scripts/Gameplay/Missions/Mission7/RoadTile.cs:
- added new SpawnBoost() function that raycasts from a random point on planes above a tile to find a point on the tile. Then does corner raycasts to ensure that the boost pad won't spawn over an edge.
- SpawnBoostRamp function now uses the SpawnBoost() function to determine if a boost pad can be spawned, and if so what the position and rotation will be
- SpawnBoostRamp() function no longer hardcodes 2 as the boost pad number, but instead uses a new maxBoostPads variable that can be set per tile (set to 2 for most, but larger tiles have more)
- replaced references to Random with UnityEngine.Random to avoid ambiguity

Assets/Prefabs/Roads/[all road tiles]:
- added new raycast spawning planes to each tile
- added values to the new maxBoostPads variable