### PR TITLE
Add Mission Start Location marker with Ready/Set/Go countdown gate

### DIFF
--- a/Assets/Prefabs/Player_New.prefab
+++ b/Assets/Prefabs/Player_New.prefab
@@ -4504,8 +4504,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   subscribed: 1
   speed: 0
-  turn: 0
-  brake: 0
   logMessages: 1
 --- !u!114 &1228870156826663968
 MonoBehaviour:

--- a/Assets/Scenes/CityScene.unity
+++ b/Assets/Scenes/CityScene.unity
@@ -1861,8 +1861,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   subscribed: 0
   speed: 0
-  turn: 0
-  brake: 0
   logMessages: 1
 --- !u!65 &144249161
 BoxCollider:
@@ -2726,6 +2724,92 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 1533754796}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &325926392
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 325926396}
+  - component: {fileID: 325926395}
+  - component: {fileID: 325926394}
+  - component: {fileID: 325926393}
+  m_Layer: 0
+  m_Name: MissionStartLocation_M1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &325926393
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 325926392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d55ba4da37994524badc49540444f566, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MissionNumber: 1
+  visualMarker: {fileID: 918039479}
+  readyDuration: 0.4
+  setDuration: 0.4
+  goDuration: 0.4
+--- !u!114 &325926394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 325926392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 29d0984697292f042a133620bd7ae69d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Mission: 1
+--- !u!65 &325926395
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 325926392}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 3, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!4 &325926396
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 325926392}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -44, y: 0, z: 31.6}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 918039480}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &327995657 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4134154446092604674, guid: f8d972788775663478934cd66f3d168b,
@@ -3866,6 +3950,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 34046703c05b13645a88b38dfaeadca1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  offlineTestMode: 0
   ActiveScene: CityScene
   NetworkPlayer: {fileID: 8071937129649633227, guid: ffa7a761264c99244b3cbc4c6dfbd0d0,
     type: 3}
@@ -6851,6 +6936,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameManager: {fileID: 126096670}
+  countdownTimer: {fileID: 0}
 --- !u!1 &892469137
 GameObject:
   m_ObjectHideFlags: 0
@@ -7218,6 +7304,86 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7464111948316513303, guid: 0722b8babe70e3b46ac265b3ca0c4db5,
     type: 3}
   m_PrefabInstance: {fileID: 914090462}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &918039478
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 325926396}
+    m_Modifications:
+    - target: {fileID: 1763783451191056315, guid: ad541d854b9546043a2771d6924f0735,
+        type: 3}
+      propertyPath: m_Name
+      value: TeleportEffect
+      objectReference: {fileID: 0}
+    - target: {fileID: 8514946137093710859, guid: ad541d854b9546043a2771d6924f0735,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8514946137093710859, guid: ad541d854b9546043a2771d6924f0735,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8514946137093710859, guid: ad541d854b9546043a2771d6924f0735,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8514946137093710859, guid: ad541d854b9546043a2771d6924f0735,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8514946137093710859, guid: ad541d854b9546043a2771d6924f0735,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8514946137093710859, guid: ad541d854b9546043a2771d6924f0735,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8514946137093710859, guid: ad541d854b9546043a2771d6924f0735,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8514946137093710859, guid: ad541d854b9546043a2771d6924f0735,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8514946137093710859, guid: ad541d854b9546043a2771d6924f0735,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8514946137093710859, guid: ad541d854b9546043a2771d6924f0735,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ad541d854b9546043a2771d6924f0735, type: 3}
+--- !u!1 &918039479 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1763783451191056315, guid: ad541d854b9546043a2771d6924f0735,
+    type: 3}
+  m_PrefabInstance: {fileID: 918039478}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &918039480 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8514946137093710859, guid: ad541d854b9546043a2771d6924f0735,
+    type: 3}
+  m_PrefabInstance: {fileID: 918039478}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &930236504
 GameObject:
@@ -69149,3 +69315,4 @@ SceneRoots:
   - {fileID: 863573008}
   - {fileID: 1241516539}
   - {fileID: 144249164}
+  - {fileID: 325926396}

--- a/Assets/Scripts/Gameplay/Missions/MissionStartLocation.cs
+++ b/Assets/Scripts/Gameplay/Missions/MissionStartLocation.cs
@@ -1,0 +1,68 @@
+using System.Collections;
+using UnityEngine;
+
+// Raised once the Ready/Set/Go sequence has finished for a given mission,
+// signalling that gameplay (Mission.StartMission) is now allowed to begin.
+// See Mission_Activator.CountdownFinished, which listens for this.
+public struct MissionCountdownFinishedEvent : IEvent
+{
+    public int MissionNumber;
+}
+
+// Place this on a marker positioned wherever a mission's gameplay should
+// actually begin - typically the same spot as that mission's MissionSpawn
+// (Assets/Scripts/UI/Objective/MissionSpawn.cs), so the player rides straight
+// up to the marker on scene load.
+//
+// Requires a trigger Collider on this GameObject (or a child) sized to cover
+// where the player spawns/arrives, and a "Player" tagged rider (see
+// TeleportGate.cs for the same tag convention used elsewhere in the project).
+//
+// Flow: player enters trigger -> Ready/Set/Go notifications play via
+// UIManager -> MissionCountdownFinishedEvent is raised -> Mission_Activator
+// flips CountdownFinished -> PlayerController allows Mission.StartMission().
+[RequireComponent(typeof(Collider))]
+public class MissionStartLocation : MonoBehaviour
+{
+    [Tooltip("Must match the Mission.MissionNumber this marker starts.")]
+    public int MissionNumber;
+
+    [Tooltip("Optional in-world visual (e.g. a reskinned portal ring) shown at the start location. Deactivated once the countdown finishes if assigned.")]
+    public GameObject visualMarker;
+
+    [Header("Ready / Set / Go timing (seconds)")]
+    [Tooltip("Hold time for each phase. UIManager.ShowNotification adds its own ~0.5s fade in/out on top of this, so actual on-screen time per phase is roughly duration + 1s. Tune during playtesting.")]
+    public float readyDuration = 0.4f;
+    public float setDuration = 0.4f;
+    public float goDuration = 0.4f;
+
+    private bool _countdownStarted;
+
+    private void OnTriggerEnter(Collider other)
+    {
+        if (_countdownStarted) return;
+        if (!other.CompareTag("Player")) return;
+
+        // only react if this marker belongs to the mission that's actually active
+        if (Mission_Activator.ActiveMission == null || Mission_Activator.ActiveMission.MissionNumber != MissionNumber)
+            return;
+
+        _countdownStarted = true;
+        StartCoroutine(RunCountdown());
+    }
+
+    private IEnumerator RunCountdown()
+    {
+        if (UIManager.Instance != null)
+        {
+            yield return UIManager.Instance.ShowNotification("Ready...", readyDuration);
+            yield return UIManager.Instance.ShowNotification("Set...", setDuration);
+            yield return UIManager.Instance.ShowNotification("GO!", goDuration);
+        }
+
+        EventBus<MissionCountdownFinishedEvent>.Raise(new MissionCountdownFinishedEvent { MissionNumber = MissionNumber });
+
+        if (visualMarker != null)
+            visualMarker.SetActive(false);
+    }
+}

--- a/Assets/Scripts/Gameplay/Missions/MissionStartLocation.cs.meta
+++ b/Assets/Scripts/Gameplay/Missions/MissionStartLocation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d55ba4da37994524badc49540444f566
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Missions/Mission_Activator.cs
+++ b/Assets/Scripts/Gameplay/Missions/Mission_Activator.cs
@@ -19,10 +19,35 @@ public class Mission_Activator : MonoBehaviour
     public int MissionNumber;
     public Mission[] Missions;
 
+    // Gates PlayerController's call to Mission.StartMission() - only true once
+    // a MissionStartLocation's Ready/Set/Go sequence has finished for the
+    // active mission. See MissionStartLocation.cs.
+    public static bool CountdownFinished { get; private set; }
+
+    private EventBinding<MissionCountdownFinishedEvent> _countdownBinding;
+
+    private void OnEnable()
+    {
+        _countdownBinding = new EventBinding<MissionCountdownFinishedEvent>(OnCountdownFinished);
+        EventBus<MissionCountdownFinishedEvent>.Register(_countdownBinding);
+    }
+
+    private void OnDisable()
+    {
+        EventBus<MissionCountdownFinishedEvent>.Deregister(_countdownBinding);
+    }
+
+    private void OnCountdownFinished(MissionCountdownFinishedEvent e)
+    {
+        if (e.MissionNumber == MissionNumber)
+            CountdownFinished = true;
+    }
+
     public void Activate(int id)
     {
         Debug.Log($"Mission {id} is Active");
         MissionNumber = id;
+        CountdownFinished = false;
 
         // loop through each mission object
         foreach (var mission in Missions)

--- a/Assets/Scripts/Gameplay/PlayerController.cs
+++ b/Assets/Scripts/Gameplay/PlayerController.cs
@@ -119,8 +119,11 @@ public class PlayerController : MonoBehaviour
 
     void Update()
     {
-        // TODO this should be moved into a mission start system, create a mission activate zone
-        if (Mission_Activator.ActiveMission != null)
+        // Mission gameplay now only starts once the player has reached a
+        // MissionStartLocation and its Ready/Set/Go countdown has finished
+        // (see MissionStartLocation.cs and Mission_Activator.CountdownFinished),
+        // instead of starting instantly on scene load.
+        if (Mission_Activator.ActiveMission != null && Mission_Activator.CountdownFinished)
         {
             if (!Mission_Activator.ActiveMission.MissionStarted)
                 Mission_Activator.ActiveMission.StartMission();

--- a/Assets/Scripts/Networking/NetworkManagement.cs
+++ b/Assets/Scripts/Networking/NetworkManagement.cs
@@ -9,8 +9,15 @@ using UnityEngine.Serialization;
 
 public class NetworkManagement : SimulationBehaviour, INetworkRunnerCallbacks
 {
+    [Header("Testing")]
+    [Tooltip("Runs Fusion in offline Single mode instead of connecting to Photon Cloud. Use this for local testing when Photon is unreachable (e.g. restrictive network/firewall). Do NOT leave this checked when you push/merge - it disables real multiplayer.")]
+    public bool offlineTestMode = false;
+
     public string ActiveScene;
-    private NetworkRunner _runner;
+    // renamed from _runner: that name collides with a field Fusion's
+    // SimulationBehaviour base class already serializes internally, which
+    // Unity flags as "The same field name is serialized multiple times".
+    private NetworkRunner _networkRunner;
     // prefabs for spawning
     public GameObject NetworkPlayer;
 
@@ -41,6 +48,16 @@ public class NetworkManagement : SimulationBehaviour, INetworkRunnerCallbacks
     
     private void OnTeleport(TeleportEvent teleportEvent)
     {
+        // guard against a TeleportGate with an unset TargetSceneName - without
+        // this, an empty target scene falls through to MapLoader's "no scene
+        // set" fallback, which force-loads AvatarSelection over whatever was
+        // running (see MapLoader.LoadAfter()).
+        if (string.IsNullOrWhiteSpace(teleportEvent.targetScene))
+        {
+            Debug.LogWarning("[NetworkManagement] OnTeleport received an empty targetScene - ignoring. Check the TeleportGate that triggered this for a blank Target Scene Name.");
+            return;
+        }
+
         Disconnect();
         MapLoader.LoadScene(teleportEvent.targetScene);
     }
@@ -63,24 +80,24 @@ public class NetworkManagement : SimulationBehaviour, INetworkRunnerCallbacks
         _players = new Dictionary<PlayerRef, NetworkObject>();
         _networkItems = new List<NetworkObject>();
 
-        _runner = gameObject.AddComponent<NetworkRunner>();
-        _runner.ProvideInput = true;
+        _networkRunner = gameObject.AddComponent<NetworkRunner>();
+        _networkRunner.ProvideInput = true;
 
-        _runner.AddCallbacks(this);
-        _runner.StartGame(new StartGameArgs
+        _networkRunner.AddCallbacks(this);
+        _networkRunner.StartGame(new StartGameArgs
         {
-            GameMode = GameMode.Shared,
+            GameMode = offlineTestMode ? GameMode.Single : GameMode.Shared,
             SessionName = ActiveScene,
             SceneManager = gameObject.AddComponent<NetworkSceneManagerDefault>()
         });
 
-        Debug.Log("Connecting...");
+        Debug.Log(offlineTestMode ? "Starting offline test session (no Photon connection)..." : "Connecting...");
     }
 
     public void Disconnect()
     {
-        _runner.Shutdown();
-        _runner.RemoveCallbacks(this);
+        _networkRunner.Shutdown();
+        _networkRunner.RemoveCallbacks(this);
     }
 
     void OnApplicationQuit()
@@ -93,7 +110,7 @@ public class NetworkManagement : SimulationBehaviour, INetworkRunnerCallbacks
         if (player == runner.LocalPlayer)
         {
             // set the spawn location for the player
-            SpawnedPlayer = _runner.Spawn(NetworkPlayer, SpawnTarget.position, SpawnTarget.rotation, player);
+            SpawnedPlayer = _networkRunner.Spawn(NetworkPlayer, SpawnTarget.position, SpawnTarget.rotation, player);
             SpawnedPlayer.name = $"Player_{player.PlayerId}";
             // hide the loading scene
             MapLoader.UnloadScene("LoadingScene");
@@ -125,6 +142,7 @@ public class NetworkManagement : SimulationBehaviour, INetworkRunnerCallbacks
 
     public void OnDisconnectedFromServer(NetworkRunner runner, NetDisconnectReason reason)
     {
+        Debug.Log($"[NetworkManagement] OnDisconnectedFromServer fired, reason: {reason} - returning to GarageScene");
         // load back to the garage when you disconnect
         MapLoader.LoadScene("GarageScene");
     }

--- a/Assets/Scripts/UI/MapLoader.cs
+++ b/Assets/Scripts/UI/MapLoader.cs
@@ -28,6 +28,7 @@ public static class MapLoader
 
     public static void LoadScene(string scene)
     {
+        Debug.Log($"[MapLoader] LoadScene requested: '{scene}' (caller triggered a full LoadingScene reload)");
         _scene = scene;
         SceneManager.LoadScene(Scene.LoadingScene.ToString());
     }
@@ -35,7 +36,11 @@ public static class MapLoader
     public static void LoadAfter()
     {
         if (string.IsNullOrEmpty(_scene))
+        {
+            Debug.LogWarning("[MapLoader] LoadAfter() called with no target scene set - falling back to 'AvatarSelection'. This means LoadScene(...) was never called with a valid name before LoadingScene ran.");
             _scene = "AvatarSelection";
+        }
+        Debug.Log($"[MapLoader] LoadAfter loading '{_scene}' additively");
         SceneManager.LoadSceneAsync(_scene, LoadSceneMode.Additive);
     }
 


### PR DESCRIPTION

<img width="633" height="517" alt="Screenshot 2026-08-04 202318" src="https://github.com/user-attachments/assets/ac301f14-8a7d-4b44-8f92-148d1f2e295a" />
<img width="643" height="512" alt="Screenshot 2026-08-04 202327" src="https://github.com/user-attachments/assets/7049f337-f1e3-4e7e-af31-4cd07d420ad8" />

- MissionStartLocation.cs: trigger-based marker that plays a Ready/Set/Go countdown and raises MissionCountdownFinishedEvent
- Mission_Activator: gates PlayerController's StartMission() call behind the countdown finishing, instead of starting instantly on scene load
- NetworkManagement: adds an offlineTestMode toggle for local testing without Photon, fixes a Fusion field-name collision (_runner -> _networkRunner), and guards OnTeleport against an empty target scene (previously force-loaded AvatarSelection on a misconfigured gate)
- MapLoader: adds diagnostic logging for scene-load requests
- CityScene: places a MissionStartLocation marker for Mission 1 and repositions a TeleportGate that was overlapping the new marker