### PR TITLE
Fix MQTT DontDestroyOnLoad warning + defensive null guards in NetworkManagement/NetworkPlayer

### DIFF
--- a/Assets/Scripts/MQTT/Mqtt.cs
+++ b/Assets/Scripts/MQTT/Mqtt.cs
@@ -52,7 +52,16 @@ public class Mqtt : MonoBehaviour
         if (_instance == null)
         {
             _instance = this;
-            DontDestroyOnLoad(gameObject);
+
+            // DontDestroyOnLoad only works on root GameObjects. The MQTT component
+            // is root in the persistent Loading/City scene objects (where we do want
+            // the connection to survive scene loads), but it is also present on a
+            // non-root child inside Player_New. Guard the call so we only invoke it
+            // where it can actually take effect, instead of letting Unity log a
+            // "DontDestroyOnLoad only works for root GameObjects" warning for the
+            // child case (where the call was always a no-op anyway).
+            if (transform.parent == null)
+                DontDestroyOnLoad(gameObject);
         }
 
         if (!string.IsNullOrWhiteSpace(PlayerPrefs.GetString("MQTTHost")))

--- a/Assets/Scripts/Networking/NetworkManagement.cs
+++ b/Assets/Scripts/Networking/NetworkManagement.cs
@@ -79,6 +79,12 @@ public class NetworkManagement : SimulationBehaviour, INetworkRunnerCallbacks
 
     public void Disconnect()
     {
+        // Defensive guard: _runner is only assigned in Start(), and Disconnect()
+        // can be reached from OnApplicationQuit/OnTeleport before that, or a
+        // second time after an earlier shutdown.
+        if (_runner == null)
+            return;
+
         _runner.Shutdown();
         _runner.RemoveCallbacks(this);
     }
@@ -92,8 +98,23 @@ public class NetworkManagement : SimulationBehaviour, INetworkRunnerCallbacks
     {
         if (player == runner.LocalPlayer)
         {
+            // Defensive guard (stopgap): SpawnTarget can be an unassigned/broken
+            // reference if no mission spawn point matched and no default was set
+            // in the inspector. Falling back to the origin avoids a hard crash
+            // here while the underlying "Resolve Null Reference in Scenes" ticket
+            // is still being investigated.
+            if (SpawnTarget == null)
+            {
+                Debug.LogWarning(
+                    $"[NetworkManagement] SpawnTarget is null when spawning player {player.PlayerId}. " +
+                    "Falling back to world origin. Check mission spawn point assignment.");
+            }
+
+            var spawnPosition = SpawnTarget != null ? SpawnTarget.position : Vector3.zero;
+            var spawnRotation = SpawnTarget != null ? SpawnTarget.rotation : Quaternion.identity;
+
             // set the spawn location for the player
-            SpawnedPlayer = _runner.Spawn(NetworkPlayer, SpawnTarget.position, SpawnTarget.rotation, player);
+            SpawnedPlayer = _runner.Spawn(NetworkPlayer, spawnPosition, spawnRotation, player);
             SpawnedPlayer.name = $"Player_{player.PlayerId}";
             // hide the loading scene
             MapLoader.UnloadScene("LoadingScene");

--- a/Assets/Scripts/Networking/NetworkPlayer.cs
+++ b/Assets/Scripts/Networking/NetworkPlayer.cs
@@ -20,11 +20,24 @@ public class NetworkPlayer : NetworkBehaviour
     private PlayerController _playerController;
     private void BikeSelectionChanged()
     {
+        // Defensive guard (stopgap): selector isn't always assigned on every
+        // player prefab variant. Log instead of crashing while the null-ref
+        // ticket is investigated.
+        if (selector == null)
+        {
+            Debug.LogWarning($"[NetworkPlayer] selector is null on {name}; cannot display bike {BikeSelection}.");
+            return;
+        }
         selector.DisplayBike(BikeSelection);
     }
-    
+
     public void BikeCustomizationChanged()
     {
+        if (SaveLoadBike == null)
+        {
+            Debug.LogWarning($"[NetworkPlayer] SaveLoadBike is null on {name}; cannot load bike customization.");
+            return;
+        }
         SaveLoadBike.LoadBikeData(BikeCustomization);
     }
 


### PR DESCRIPTION
Addresses part of the "Unity VR: Resolve Null Reference in Scenes" ticket.

*Mqtt.cs — fixed*
`DontDestroyOnLoad(gameObject)` was throwing "DontDestroyOnLoad only works for root GameObjects." Root cause: `Mqtt` is root in `LoadingScene`/`CityScene` (where persistence across scene loads is intended), but it's also on a non-root child inside `Player_New.prefab`, where the call was always a silent no-op. Wrapped the call in `if (transform.parent == null)` so it only fires where it can take effect. No behavior change for the legitimate persistent-connection case.

*NetworkManagement.cs / NetworkPlayer.cs — defensive guards, not a confirmed root-cause fix*
Added null checks at the concrete crash points found during investigation, since the ticket's actual VR-positional-data null ref hasn't been reproduced/traced yet:
- `OnPlayerJoined`: falls back to world origin (with a warning) if `SpawnTarget` is null instead of crashing on `.position`.
- `Disconnect()`: returns early if `_runner` is null instead of crashing on `.Shutdown()`.
- `NetworkPlayer.BikeSelectionChanged` / `BikeCustomizationChanged`: warn and bail if `selector`/`SaveLoadBike` aren't assigned, instead of crashing.

*Still open:* the specific NullReferenceException tied to VR hardware positional data (noted as "pending further investigation" in the ticket) is not yet reproduced. `LocalPlayer.cs` (the only script reading `XRNode` head/hand data) is already null-safe and isn't wired into any scene/prefab, so it can't be the current source. Need a Unity console stack trace to pin down the actual line.

**Testing:** Not yet run in-editor/on-device — recommend a flatscreen playtest of the City scene spawn flow and an MQTT-connected playtest to confirm no regressions before merging.